### PR TITLE
Fix: clean rule 

### DIFF
--- a/carolette.sh
+++ b/carolette.sh
@@ -9,6 +9,6 @@ LIBFT_PATH=$(pwd)
 cd ~/carolette
 
 # Run make with the dynamically set LIBFT_PATH
-make LIBFT_PATH="$LIBFT_PATH" && ./libft_tests && make fclean
+make LIBFT_PATH="$LIBFT_PATH" && ./libft_tests
 
-cd $LIBFT_PATH && make fclean
+make fclean


### PR DESCRIPTION
# Only cleans the carolette files
- libft generated files remains, since we will clean using make re when running the tests again with carolette command that way if the user is using clean rule we do not lose the output from carolette.

### The example below shows a 
```sh
@clear
```

![image](https://github.com/user-attachments/assets/b6e6c1cd-ec86-4a3e-9d0c-a3802afa0df2)
at the user fclean. So, if we clean the files the *clear* will hide the carolette output. we prevent that behavior by only cleaning the carolette generated files.

The rest remains ok!
![image](https://github.com/user-attachments/assets/08627f16-ae9e-4f6c-bd4c-eaecea915a00)

