### PR TITLE
Fix/isalpha

### DIFF
--- a/tests/ft_isalnum_test.c
+++ b/tests/ft_isalnum_test.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ft_isalnum_test.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: cade-oli <cade-oli@student.42porto.com>    +#+  +:+       +#+        */
+/*   By: abessa-m <abessa-m@student.42porto.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/23 15:42:47 by cade-oli          #+#    #+#             */
-/*   Updated: 2024/10/23 15:43:37 by cade-oli         ###   ########.fr       */
+/*   Updated: 2024/10/26 16:27:42 by abessa-m         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,7 @@
 
 int	ft_isalnum_test(void)
 {
-	int	chars[] = {'A', 'z', 'b', 'G', '!', '0', '9', -1, 128};
+	int	chars[] = {'A', 'z', 'b', 'G', '!', '0', '9', -1, 128, '\t'};
 	int	num_tests;
 	int	i;
 	int	c;
@@ -32,9 +32,7 @@ int	ft_isalnum_test(void)
 	{
 		c = chars[i];
 		original = isalnum(c);
-		if (original > 0)
-			original = 1;
-		if (original == ft_isalnum(c))
+		if (!isalnum(c) == !ft_isalnum(c))
 			printf("%s[✔] Test passed for input '%c' (ASCII: %d)%s\n",
 				GREEN, c, c, RESET);
 		else
@@ -44,3 +42,4 @@ int	ft_isalnum_test(void)
 	printf("\n");
 	return (0);
 }
+

--- a/tests/ft_isalnum_test.c
+++ b/tests/ft_isalnum_test.c
@@ -6,7 +6,7 @@
 /*   By: abessa-m <abessa-m@student.42porto.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/23 15:42:47 by cade-oli          #+#    #+#             */
-/*   Updated: 2024/10/26 16:27:42 by abessa-m         ###   ########.fr       */
+/*   Updated: 2024/10/26 17:21:08 by abessa-m         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,7 +32,7 @@ int	ft_isalnum_test(void)
 	{
 		c = chars[i];
 		original = isalnum(c);
-		if (!isalnum(c) == !ft_isalnum(c))
+		if (!original == !ft_isalnum(c))
 			printf("%s[✔] Test passed for input '%c' (ASCII: %d)%s\n",
 				GREEN, c, c, RESET);
 		else

--- a/tests/ft_isalpha_test.c
+++ b/tests/ft_isalpha_test.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ft_isalpha_test.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: cade-oli <cade-oli@student.42porto.com>    +#+  +:+       +#+        */
+/*   By: abessa-m <abessa-m@student.42porto.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/23 12:07:05 by cade-oli          #+#    #+#             */
-/*   Updated: 2024/10/23 16:43:00 by cade-oli         ###   ########.fr       */
+/*   Updated: 2024/10/26 17:20:56 by abessa-m         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,7 @@
 
 int	ft_isalpha_test(void)
 {
-	int	chars[] = {'A', 'z', 'b', 'G', '!', '0', '9', -1, 128};
+	int	chars[] = {'A', 'z', 'b', 'G', '!', '0', '9', -1, 128, '\t'};
 	int	num_tests;
 	int	i;
 	int	c;
@@ -32,9 +32,7 @@ int	ft_isalpha_test(void)
 	{
 		c = chars[i];
 		original = isalpha(c);
-		if (original > 0)
-			original = 1;
-		if (original == ft_isalpha(c))
+		if (!original == !ft_isalpha(c))
 			printf("%s[✔] Test passed for input '%c' (ASCII: %d)%s\n",
 				GREEN, c, c, RESET);
 		else

--- a/tests/ft_isascii_test.c
+++ b/tests/ft_isascii_test.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ft_isascii_test.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: cade-oli <cade-oli@student.42porto.com>    +#+  +:+       +#+        */
+/*   By: abessa-m <abessa-m@student.42porto.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/23 15:49:14 by cade-oli          #+#    #+#             */
-/*   Updated: 2024/10/23 15:49:41 by cade-oli         ###   ########.fr       */
+/*   Updated: 2024/10/26 17:20:37 by abessa-m         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,7 @@
 
 int	ft_isascii_test(void)
 {
-	int	chars[] = {'A', 'z', 'b', 'G', '!', '0', '9', -1, 128};
+	int	chars[] = {'A', 'z', 'b', 'G', '!', '0', '9', -1, 128, '\t'};
 	int	num_tests;
 	int	i;
 	int	c;
@@ -32,9 +32,7 @@ int	ft_isascii_test(void)
 	{
 		c = chars[i];
 		original = isascii(c);
-		if (original > 0)
-			original = 1;
-		if (original == ft_isascii(c))
+		if (!original == !ft_isascii(c))
 			printf("%s[✔] Test passed for input '%c' (ASCII: %d)%s\n",
 				GREEN, c, c, RESET);
 		else

--- a/tests/ft_isdigit_test.c
+++ b/tests/ft_isdigit_test.c
@@ -18,7 +18,7 @@
 int	ft_isdigit_test(void)
 {
 	int chars[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-					'A', 'z', '!', -1, 128};
+					'A', 'z', '!', -1, 128, '\t'};
 	int	i;
 	int	test_len;
 	int	c;
@@ -33,9 +33,7 @@ int	ft_isdigit_test(void)
 	{
 		c = chars[i];
 		original = isdigit(c);
-		if (original > 0)
-			original = 1;
-		if (original == ft_isdigit(c))
+		if (!original == !ft_isdigit(c))
 			printf("%s[✔] Test passed for input '%c' (ASCII: %d)%s\n",
 				GREEN, c, c, RESET);
 		else


### PR DESCRIPTION
Inverted the comparison to the original functions, in order to follow the intended return value of "zero or not" from the manual pages.

This is to prevent false positives when the non-zero return is not exactly 1:
![Screenshot from 2024-10-26 16-25-08](https://github.com/user-attachments/assets/a9f77600-ef7b-4900-81be-332283872744)

----
Additionally, added testing for '\t'.
